### PR TITLE
Fix 'parameter name omitted' error msg on gcc

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -2,7 +2,7 @@ sources = files (
     'rpcc.c'
 )
 
-add_global_arguments('-Wno-unused-result', language : 'c')
+add_global_arguments('-Wno-unused-parameter', language : 'c')
 
 gtk = dependency ('gtk+-3.0')
 deps = [ gtk ]

--- a/src/rpcc.c
+++ b/src/rpcc.c
@@ -91,7 +91,7 @@ static gboolean draw (GtkWidget *wid, cairo_t *cr, gpointer data);
 /* Plugin management */
 /*----------------------------------------------------------------------------*/
 
-static void load_plugin (GtkWidget *, const char *filename)
+static void load_plugin (GtkWidget *widget, const char *filename)
 {
     GtkWidget *label, *page, *icon, *box;
     void *phandle;
@@ -169,7 +169,7 @@ static void load_plugin (GtkWidget *, const char *filename)
     plugin_handles = g_list_append (plugin_handles, phandle);
 }
 
-static void free_plugins (void *phandle, gpointer)
+static void free_plugins (void *phandle, gpointer data)
 {
     free_plugin = dlsym (phandle, "free_plugin");
     free_plugin ();
@@ -194,7 +194,7 @@ const char *dgetfixt (const char *domain, const char *msgctxid)
     return strchr (msgctxid, 0x04) + 1;
 }
 
-static void update_icons (GtkWidget *, gpointer)
+static void update_icons (GtkWidget *widget, gpointer data)
 {
     GtkWidget *icon;
     GdkPixbuf *pixbuf;
@@ -241,7 +241,7 @@ void clear_watch_cursor (void)
 /* Reboot prompt */
 /*----------------------------------------------------------------------------*/
 
-static void reboot_check (void *phandle, gpointer)
+static void reboot_check (void *phandle, gpointer data)
 {
     reboot_needed = dlsym (phandle, "reboot_needed");
     if (reboot_needed ()) reboot = TRUE;
@@ -287,14 +287,14 @@ static void close_with_prompt (void)
     else gtk_main_quit ();
 }
 
-static gboolean close_app (GtkButton *button, gpointer)
+static gboolean close_app (GtkButton *button, gpointer data)
 {
     gtk_widget_destroy (msg_dlg);
     gtk_main_quit ();
     return FALSE;
 }
 
-static gboolean close_app_reboot (GtkButton *button, gpointer)
+static gboolean close_app_reboot (GtkButton *button, gpointer data)
 {
     gtk_widget_destroy (msg_dlg);
     gtk_main_quit ();
@@ -338,7 +338,7 @@ static gboolean close_prog (GtkWidget *widget, GdkEvent *event, gpointer data)
     return TRUE;
 }
 
-static gboolean scroll (GtkWidget *, GdkEventScroll *ev, gpointer)
+static gboolean scroll (GtkWidget *widget, GdkEventScroll *ev, gpointer data)
 {
     int page;
 
@@ -424,7 +424,7 @@ static void save_config (void)
 /* Startup */
 /*----------------------------------------------------------------------------*/
 
-static gboolean init_window (gpointer)
+static gboolean init_window (gpointer data)
 {
     GtkBuilder *builder;
     GdkWindow *win;


### PR DESCRIPTION
Without naming the arguments I get the following errors (on gcc 10.2.1):

<details><summary>compile log</summary>

```
$ meson compile -C build_tmp
INFO: autodetecting backend as ninja
INFO: calculating backend command to run: /usr/bin/ninja -C /home/user/dev/rpcc/build_tmp
ninja: Entering directory `/home/user/dev/rpcc/build_tmp'
[5/6] Compiling C object src/rpcc.p/rpcc.c.o
FAILED: src/rpcc.p/rpcc.c.o
cc -Isrc/rpcc.p -Isrc -I../src -I/usr/include/gtk-3.0 -I/usr/include/pango-1.0 -I/usr/include/glib-2.0 -I/usr/lib/aarch64-linux-gnu/glib-2.0/include -I/usr/include/harfbuzz -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/fribidi -I/usr/include/uuid -I/usr/include/cairo -I/usr/include/pixman-1 -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/gio-unix-2.0 -I/usr/include/atk-1.0 -I/usr/include/at-spi2-atk/2.0 -I/usr/include/dbus-1.0 -I/usr/lib/aarch64-linux-gnu/dbus-1.0/include -I/usr/include/at-spi-2.0 -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O0 -g '-DGETTEXT_PACKAGE="rpcc"' '-DPACKAGE_LOCALE_DIR="/usr/local/share/locale"' '-DPACKAGE_DATA_DIR="/usr/local/share/rpcc"' -Wno-unused-result -pthread '-DPLUGIN_PATH="/usr/local/lib/aarch64-linux-gnu/rpcc/"' -MD -MQ src/rpcc.p/rpcc.c.o -MF src/rpcc.p/rpcc.c.o.d -o src/rpcc.p/rpcc.c.o -c ../src/rpcc.c
../src/rpcc.c: In function ‘load_plugin’:
../src/rpcc.c:94:26: error: parameter name omitted
   94 | static void load_plugin (GtkWidget *, const char *filename)
      |                          ^~~~~~~~~~~
../src/rpcc.c: In function ‘free_plugins’:
../src/rpcc.c:172:42: error: parameter name omitted
  172 | static void free_plugins (void *phandle, gpointer)
      |                                          ^~~~~~~~
../src/rpcc.c: In function ‘update_icons’:
../src/rpcc.c:197:27: error: parameter name omitted
  197 | static void update_icons (GtkWidget *, gpointer)
      |                           ^~~~~~~~~~~
../src/rpcc.c:197:40: error: parameter name omitted
  197 | static void update_icons (GtkWidget *, gpointer)
      |                                        ^~~~~~~~
../src/rpcc.c: In function ‘reboot_check’:
../src/rpcc.c:244:42: error: parameter name omitted
  244 | static void reboot_check (void *phandle, gpointer)
      |                                          ^~~~~~~~
../src/rpcc.c: In function ‘close_app’:
../src/rpcc.c:290:47: error: parameter name omitted
  290 | static gboolean close_app (GtkButton *button, gpointer)
      |                                               ^~~~~~~~
../src/rpcc.c: In function ‘close_app_reboot’:
../src/rpcc.c:297:54: error: parameter name omitted
  297 | static gboolean close_app_reboot (GtkButton *button, gpointer)
      |                                                      ^~~~~~~~
../src/rpcc.c: In function ‘scroll’:
../src/rpcc.c:341:25: error: parameter name omitted
  341 | static gboolean scroll (GtkWidget *, GdkEventScroll *ev, gpointer)
      |                         ^~~~~~~~~~~
../src/rpcc.c:341:58: error: parameter name omitted
  341 | static gboolean scroll (GtkWidget *, GdkEventScroll *ev, gpointer)
      |                                                          ^~~~~~~~
../src/rpcc.c: In function ‘init_window’:
../src/rpcc.c:427:30: error: parameter name omitted
  427 | static gboolean init_window (gpointer)
      |                              ^~~~~~~~
ninja: build stopped: subcommand failed.
```

</details>