### PR TITLE
Add hello-world plugin

### DIFF
--- a/plugins/hello_world.c
+++ b/plugins/hello_world.c
@@ -1,0 +1,55 @@
+#include "rpcc_api.h"
+
+static GtkWidget *root = NULL;
+
+void
+init_plugin(void)
+{
+}
+
+int
+plugin_tabs(void)
+{
+	return 1;
+}
+
+const char *
+tab_name(int tab)
+{
+	return "hello world!";
+}
+
+const char *
+tab_id(int tab)
+{
+	return "hello-world-example";
+}
+
+GtkWidget *
+get_tab(int tab)
+{
+	if (!root) {
+		root = gtk_label_new("Hello world!");
+		gtk_widget_show(root);
+	}
+	return root;
+}
+
+const char *
+icon_name(int tab)
+{
+	return "applications-system";
+}
+
+gboolean
+reboot_needed(void)
+{
+	return FALSE;
+}
+
+void
+free_plugin(void)
+{
+	/* widget is destroyed by rpcc */
+	root = NULL;
+}

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -1,0 +1,8 @@
+sources = files (
+	'hello_world.c',
+)
+
+gtk = dependency('gtk+-3.0')
+deps = [ gtk ]
+
+shared_module('hello_world', sources, dependencies: deps, install: false)

--- a/plugins/rpcc_api.h
+++ b/plugins/rpcc_api.h
@@ -1,0 +1,64 @@
+#include <gtk/gtk.h>
+
+/*
+ * Called when the plugin is first loaded to perform
+ * any initialisation it requires, including setting
+ * translation domain.
+ */
+void init_plugin(void);
+
+/*
+ * Should return the number of tab pages the plugin
+ * provides. Must be 1 or greater.
+ */
+int plugin_tabs(void);
+
+/*
+ * For the numbered tab, return the title which should
+ * be displayed for it. International translations for
+ * these should be included in the plugin; use the
+ * C_ macro with the context "tab" to define these names.
+ */
+const char *tab_name(int tab);
+
+/*
+ * For the numbered tab, return a unique ID string which
+ * can be used to identify the tab. This is optional - the
+ * ID is only used if direct access to the tab is needed by
+ * executing "rpcc <tab_id>", which will then launch the
+ * application with that tab open.
+ * Return NULL for any tabs for which this is not required.
+ */
+const char *tab_id(int tab);
+
+/*
+ * For the numbered tab, return the widget (usually a box)
+ * containing the controls. The widget must have no parent
+ * when it is returned, so may need to be removed (using
+ * gtk_container_remove) from any parent in which it is
+ * defined, such as a GtkWindow toplevel in a UI file.
+ * The widget will be displayed in the relevant tab of rpcc.
+ * All controls should take effect in real time, with a busy
+ * mouse cursor displayed by the plugin if required.
+ */
+ GtkWidget *get_tab(int tab);
+
+/*
+ * For the numbered tab, return the name of the icon in
+ * a loaded icon theme which should be displayed for it.
+ */
+const char *icon_name(int tab);
+
+/*
+ * Called when the application is closed to tidy up and determine
+ * if any control change made while the tab was running requires
+ * a reboot. Should return TRUE if a reboot is required;
+ * FALSE otherwise.
+ */
+gboolean reboot_needed(void);
+
+/*
+ * Called when the application is closed to
+ * unload the plugin resources from memory.
+ */
+void free_plugin(void);


### PR DESCRIPTION
This is currently not included in the main `meson.build` file so this is not actually compiled at all.

I do have other local meson changes which allow to run everything straight from the build directory (e.g. `PACKAGE_DATA_DIR` and `PLUGIN_PATH` are changed). Any ideas how to properly set everything up so this becomes an optional example would be welcome (if the whole thing makes sense for this project in the first place).